### PR TITLE
fixes #48 - Added support to read parked connection TTL from Client yaml

### DIFF
--- a/src/main/java/com/networknt/client/builder/CacheableConnection.java
+++ b/src/main/java/com/networknt/client/builder/CacheableConnection.java
@@ -57,7 +57,7 @@ public class CacheableConnection {
      */
     public CacheableConnection(ClientConnection clientConnection, long ttl, int maxReqCount, long ttlParked) {
         this(clientConnection, ttl, maxReqCount);
-        this.ttlParked = ttlParked;
+        if(ttlParked > 0) this.ttlParked = ttlParked;  //ttlParked is 0 set default value 1 min
     }
 
     public boolean isOpen() {

--- a/src/main/java/com/networknt/client/builder/ConnectionCacheManager.java
+++ b/src/main/java/com/networknt/client/builder/ConnectionCacheManager.java
@@ -54,7 +54,7 @@ public class ConnectionCacheManager {
      * @param isHttp2Enabled Whether an http2 or http1 connection will be made.
      * @return A connection to the host.
      */
-    public ClientConnection getConnection(URI hostUri, long connectionTTL, TimeoutDef connectionRequestTimeout, boolean isHttp2Enabled, int requestCount) throws InterruptedException, ExecutionException, TimeoutException {
+    public ClientConnection getConnection(URI hostUri, long connectionTTL, TimeoutDef connectionRequestTimeout, boolean isHttp2Enabled, int requestCount, long parkedConnectionTTL) throws InterruptedException, ExecutionException, TimeoutException {
         synchronized (ConnectionCacheManager.class) {
             CacheableConnection connection = clientConnectionMap.get(hostUri.toString());
             if (connection != null && connection.isOpen()) {
@@ -63,7 +63,7 @@ public class ConnectionCacheManager {
             }
             handleParkedConnection(hostUri.toString(), connection);
             logger.debug("Creating a new connection to: " + hostUri);
-            CacheableConnection cacheableConnection = new CacheableConnection(this.connect(hostUri, connectionRequestTimeout, isHttp2Enabled), connectionTTL,requestCount);
+            CacheableConnection cacheableConnection = new CacheableConnection(this.connect(hostUri, connectionRequestTimeout, isHttp2Enabled), connectionTTL,requestCount,parkedConnectionTTL);
 
             clientConnectionMap.put(hostUri.toString(), cacheableConnection);
             return cacheableConnection.getCachedConnection();

--- a/src/main/java/com/networknt/client/builder/HttpClientBuilder.java
+++ b/src/main/java/com/networknt/client/builder/HttpClientBuilder.java
@@ -94,7 +94,7 @@ public class HttpClientBuilder {
 
         ClientConnection clientConnection = connectionCacheManager.getConnection(requestHost,
                 httpClientRequest.getConnectionCacheTTLms(), httpClientRequest.getConnectionRequestTimeout(),
-                httpClientRequest.getHttp2Enabled(),httpClientRequest.getMaxReqCount());
+                httpClientRequest.getHttp2Enabled(),httpClientRequest.getMaxReqCount(),httpClientRequest.getParkedConnectionTTL());
 
         // Send the request
         clientConnection.sendRequest(httpClientRequest.getClientRequest(), this.getClientCallback(httpClientRequest.getResponseReference()));
@@ -228,6 +228,10 @@ public class HttpClientBuilder {
     }
     public HttpClientBuilder setMaxReqCount(int maxReqCount) {
         this.httpClientRequest.setMaxReqCount(maxReqCount);
+        return this;
+    }
+    public HttpClientBuilder setParkedConnectionTTL(long ttlParked) {
+        this.httpClientRequest.setParkedConnectionTTL(ttlParked);
         return this;
     }
 }

--- a/src/main/java/com/networknt/client/builder/HttpClientRequest.java
+++ b/src/main/java/com/networknt/client/builder/HttpClientRequest.java
@@ -43,6 +43,7 @@ public class HttpClientRequest implements AutoCloseable {
     private String apiHost;
 
     private int maxReqCount=-1;
+    private long parkedConnectionTTL;
 
 
     // Cached thread pool as we might expect many short-lived threads..
@@ -187,5 +188,13 @@ public class HttpClientRequest implements AutoCloseable {
 
     public void setMaxReqCount(int maxReqCount) {
         this.maxReqCount = maxReqCount;
+    }
+
+    public long getParkedConnectionTTL() {
+        return parkedConnectionTTL;
+    }
+
+    public void setParkedConnectionTTL(long parkedConnectionTTL) {
+        this.parkedConnectionTTL = parkedConnectionTTL;
     }
 }

--- a/src/test/java/com/networknt/client/builder/ConnectionCacheManagerTest.java
+++ b/src/test/java/com/networknt/client/builder/ConnectionCacheManagerTest.java
@@ -32,14 +32,14 @@ public class ConnectionCacheManagerTest {
      */
     //@Test
     public void testCacheableConnection() throws Exception {
-        ClientConnection connection0 = manager.getConnection(uri, 2000, new TimeoutDef(2, TimeUnit.SECONDS), true, 1000);
-        ClientConnection connection1 = manager.getConnection(uri, 2000, new TimeoutDef(2, TimeUnit.SECONDS), true, 1000);
+        ClientConnection connection0 = manager.getConnection(uri, 2000, new TimeoutDef(2, TimeUnit.SECONDS), true, 1000,60000);
+        ClientConnection connection1 = manager.getConnection(uri, 2000, new TimeoutDef(2, TimeUnit.SECONDS), true, 1000,60000);
         Assert.assertTrue(connection0 == connection1); // Both connections should be the same instance.
         Thread.sleep(3000);
-        ClientConnection connection2 = manager.getConnection(uri, 2000, new TimeoutDef(2, TimeUnit.SECONDS), true, 1000);
+        ClientConnection connection2 = manager.getConnection(uri, 2000, new TimeoutDef(2, TimeUnit.SECONDS), true, 1000,60000);
         Assert.assertFalse(connection1 == connection2); // The connection 1 is expired and moved to the parked map. connection2 is another instance.
         Thread.sleep(3000);
-        ClientConnection connection3 = manager.getConnection(uri, 2000, new TimeoutDef(2, TimeUnit.SECONDS), true, 1000);
+        ClientConnection connection3 = manager.getConnection(uri, 2000, new TimeoutDef(2, TimeUnit.SECONDS), true, 1000,60000);
         Assert.assertFalse(connection1.isOpen()); // at this moment, the connection1 is closed if parked ttl is set to 100 milliseconds for debugging.
         Assert.assertTrue(connection2.isOpen());
         Assert.assertTrue(connection3.isOpen());

--- a/src/test/java/com/networknt/client/builder/TestHttpClientBuilder.java
+++ b/src/test/java/com/networknt/client/builder/TestHttpClientBuilder.java
@@ -68,7 +68,7 @@ public class TestHttpClientBuilder {
         PowerMockito.when(httpClientRequest.getMaxReqCount()).thenReturn(-1);
         when(httpClientRequest.getApiHost()).thenReturn("https://localhost:8080");
         uri = new URI("https://localhost:8080");
-        when(connectionCacheManager.getConnection(uri, 10000, null, true, -1)).thenReturn(clientConnection);
+        when(connectionCacheManager.getConnection(uri, 10000, null, true, -1,60000)).thenReturn(clientConnection);
     }
 
     //@Test


### PR DESCRIPTION
Changes to read  parked connection TTL from Client.yml file. 